### PR TITLE
Relax ITensorMPS compat to support 0.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,3 +139,12 @@ breaking changes; see each entry below.
   (`schmidt-4`).
 - Continuous-integration workflow running the test suite on Julia 1.10 and
   latest across Ubuntu and macOS.
+
+### Changed
+- Relaxed the `ITensorMPS` compatibility bound from `^0.3` to `0.3, 0.4` so
+  downstream environments can upgrade to ITensorMPS 0.4.x. Verified against
+  ITensorMPS v0.4.1 (resolving alongside ITensors v0.9.30 / NDTensors v0.4.28):
+  the full test suite — including every MPS/MPO, Pauli-space, and TEBD
+  conversion — passes unchanged. The existing `ITensors` (`0.7, 0.8, 0.9`) and
+  `KrylovKit` (`0.8, 0.9, 0.10`) bounds already cover ITensorMPS 0.4.x's
+  requirements, so no other compat entries needed to change (#14).

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 Combinatorics = "^1.0"
-ITensorMPS = "^0.3"
+ITensorMPS = "0.3, 0.4"
 ITensors = "0.7, 0.8, 0.9"
 julia = "1.10"
 KrylovKit = "0.8, 0.9, 0.10"


### PR DESCRIPTION
Closes #14.

## Problem

`Project.toml` pinned `ITensorMPS = "^0.3"`, which prevented downstream
environments from upgrading to ITensorMPS 0.4.x (reported in #14).

## Change

Relax the bound to `ITensorMPS = "0.3, 0.4"`.

ITensorMPS 0.4.0/0.4.1 require `ITensors 0.8–0.9` and `KrylovKit 0.8.1–0.10`,
both already inside EDKit's existing compat bounds (`ITensors = "0.7, 0.8, 0.9"`,
`KrylovKit = "0.8, 0.9, 0.10"`), so the `ITensorMPS` entry was the only one that
needed widening. (`entropy`, the one MPS-adjacent symbol worth checking, is
defined in EDKit itself, not imported from ITensorMPS.)

## Verification

Resolved and ran the full suite with the relaxed bound:

- Resolution selects **ITensorMPS v0.4.1** (with ITensors v0.9.30,
  NDTensors v0.4.28, KrylovKit v0.10.3); EDKit precompiles and loads cleanly.
- **`Pkg.test()` passes in full** under 0.4.1, including the ITensor-heavy
  testsets:
  - `ITensor Integration` — 23/23 (MPS↔vector, operator conversion,
    symmetry-resolved `mps2vec`, Pauli utilities, PMPS/MPO conversion, TEBD)
  - `Pauli PMPS fidelity round-trip` — 6/6
  - `MPS → PMPS round-trip` — 6/6

## Note for the maintainer

This fix only reaches users once a new version is tagged/registered.
`Project.toml` currently reads `version = "0.5.1"` while `CHANGELOG.md` targets
`0.6.0` and the latest tag is `v0.5.0` — left untouched here since the version
bump is a release decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)